### PR TITLE
options_submit() from views_plugin_display to match parent class's method signature

### DIFF
--- a/views_content/plugins/views/views_content_plugin_display_ctools_context.inc
+++ b/views_content/plugins/views/views_content_plugin_display_ctools_context.inc
@@ -136,7 +136,7 @@ class views_content_plugin_display_ctools_context extends views_plugin_display {
    * Perform any necessary changes to the form values prior to storage.
    * There is no need for this function to actually store the data.
    */
-  function options_submit(&$form, &$form_state) {
+  function options_submit($form, &$form_state) {
     // It is very important to call the parent function here:
     parent::options_submit($form, $form_state);
     switch ($form_state['section']) {

--- a/views_content/plugins/views/views_content_plugin_display_panel_pane.inc
+++ b/views_content/plugins/views/views_content_plugin_display_panel_pane.inc
@@ -317,7 +317,7 @@ class views_content_plugin_display_panel_pane extends views_plugin_display {
    * Perform any necessary changes to the form values prior to storage.
    * There is no need for this function to actually store the data.
    */
-  function options_submit(&$form, &$form_state) {
+  function options_submit($form, &$form_state) {
     // It is very important to call the parent function here:
     parent::options_submit($form, $form_state);
     switch ($form_state['section']) {


### PR DESCRIPTION
The method options_submit() doesn't match views parent signature and makes $form a reference. 

> WD php: Declaration of views_content_plugin_display_panel_pane::options_submit(&$form, &$form_state) should be compatible with views_plugin_display::options_submit($form, &$form_state)

This patch de-references the $form param.