### PR TITLE
Fix deprecation warnings for each()

### DIFF
--- a/includes/menu.inc
+++ b/includes/menu.inc
@@ -79,7 +79,8 @@ function ctools_get_menu_trail($path = NULL) {
   }
 
   $tree = ctools_menu_tree_page_data($item, menu_get_active_menu_name());
-  list($key, $curr) = each($tree);
+  $curr = current($tree);
+  next($tree);
 
   while ($curr) {
     // Terminate the loop when we find the current path in the active trail.
@@ -93,7 +94,8 @@ function ctools_get_menu_trail($path = NULL) {
         $trail[] = $curr['link'];
         $tree = $curr['below'] ? $curr['below'] : array();
       }
-      list($key, $curr) = each($tree);
+      $curr = current($tree);
+      next($tree);
     }
   }
   // Make sure the current page is in the trail (needed for the page title),


### PR DESCRIPTION
each() is deprecated in PHP7 and removed in 8.
ctools_get_menu_trail() is a replacement for menu_set_active_trail() in core.  This commit updates  ctools_get_menu_trail() with the same fix made to menu_set_active_trail() made in 5bfd1fa224b0c3bd8094f54ddcbe1b17131b6e76
